### PR TITLE
Add about page route displaying deployment region

### DIFF
--- a/app.go
+++ b/app.go
@@ -28,6 +28,14 @@ func main() {
 		t.ExecuteTemplate(w, "index.html.tmpl", data)
 	})
 
+	http.HandleFunc("/about", func(w http.ResponseWriter, r *http.Request) {
+		data := map[string]string{
+			"Region": os.Getenv("FLY_REGION"),
+		}
+
+		t.ExecuteTemplate(w, "about.html.tmpl", data)
+	})
+
 	log.Println("listening on", port)
 	log.Fatal(http.ListenAndServe(":"+port, nil))
 }

--- a/templates/about.html.tmpl
+++ b/templates/about.html.tmpl
@@ -3,10 +3,11 @@
 <head>
 </head>
 <body>
-<h1>Hello from Fly</h1>
+<h1>About</h1>
+<p>This is a simple about page.</p>
 {{ if .Region }}
 <h2>I'm running in the {{.Region}} region</h2>
-{{end}}
+{{ end }}
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- add /about route and template
- show fly deployment region on the about page

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68969a1a85a48321990cb1281ab743dc