### PR TITLE
Add SQL schema for users, tweets, and comments

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    username TEXT NOT NULL UNIQUE,
+    profile_name TEXT,
+    profile_url TEXT
+);
+
+CREATE TABLE IF NOT EXISTS tweets (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    likes INTEGER NOT NULL DEFAULT 0,
+    saves INTEGER NOT NULL DEFAULT 0,
+    restacks INTEGER NOT NULL DEFAULT 0,
+    replies INTEGER NOT NULL DEFAULT 0,
+    is_edited BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_edited_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS comments (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    tweet_id INTEGER NOT NULL REFERENCES tweets(id),
+    likes INTEGER NOT NULL DEFAULT 0,
+    replies INTEGER NOT NULL DEFAULT 0,
+    is_edited BOOLEAN NOT NULL DEFAULT FALSE,
+    last_edited_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- add `schema.sql` defining `users`, `tweets`, and `comments` tables

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897c7e00d608321a761780f595e5b80