### PR TITLE
Add body and bio fields to SQL schema

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -9,11 +9,13 @@ type User struct {
 	Username    string    `json:"username"`
 	ProfileName string    `json:"profile_name"`
 	ProfileURL  string    `json:"profile_url"`
+	Bio         string    `json:"bio"`
 }
 
 type Tweet struct {
 	ID           int       `json:"id"`
 	UserID       int       `json:"user_id"`
+	Body         string    `json:"body"`
 	Likes        int       `json:"likes"`
 	Saves        int       `json:"saves"`
 	Restacks     int       `json:"restacks"`
@@ -27,6 +29,7 @@ type Comment struct {
 	ID           int       `json:"id"`
 	UserID       int       `json:"user_id"`
 	TweetID      int       `json:"tweet_id"`
+	Body         string    `json:"body"`
 	Likes        int       `json:"likes"`
 	Replies      int       `json:"replies"`
 	IsEdited     bool      `json:"is_edited"`

--- a/schema.sql
+++ b/schema.sql
@@ -3,12 +3,14 @@ CREATE TABLE IF NOT EXISTS users (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     username TEXT NOT NULL UNIQUE,
     profile_name TEXT,
-    profile_url TEXT
+    profile_url TEXT,
+    bio TEXT
 );
 
 CREATE TABLE IF NOT EXISTS tweets (
     id SERIAL PRIMARY KEY,
     user_id INTEGER NOT NULL REFERENCES users(id),
+    body TEXT NOT NULL,
     likes INTEGER NOT NULL DEFAULT 0,
     saves INTEGER NOT NULL DEFAULT 0,
     restacks INTEGER NOT NULL DEFAULT 0,
@@ -22,6 +24,7 @@ CREATE TABLE IF NOT EXISTS comments (
     id SERIAL PRIMARY KEY,
     user_id INTEGER NOT NULL REFERENCES users(id),
     tweet_id INTEGER NOT NULL REFERENCES tweets(id),
+    body TEXT NOT NULL,
     likes INTEGER NOT NULL DEFAULT 0,
     replies INTEGER NOT NULL DEFAULT 0,
     is_edited BOOLEAN NOT NULL DEFAULT FALSE,


### PR DESCRIPTION
## Summary
- Include `bio` field on `users` table
- Add `body` field to `tweets` and `comments`
- Regenerate Go models to reflect new columns

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897cec562908321a08df38b54a42f06