### PR TITLE
Add tweet and user route handlers

### DIFF
--- a/home.go
+++ b/home.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	postgrest "github.com/supabase-community/postgrest-go"
+)
+
+func init() {
+	http.HandleFunc("/home", homeHandler)
+}
+
+// homeHandler returns the 10 most recent tweets with user information.
+func homeHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	client, err := getSupabase(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var tweets []TweetWithUser
+	qb := client.From("tweets").Select("*,users(*)", "", false)
+	qb = qb.Order("created_at", &postgrest.OrderOpts{Ascending: false})
+	qb = qb.Limit(10, "")
+	if _, err := qb.ExecuteTo(&tweets); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(tweets)
+}

--- a/tweet_routes.go
+++ b/tweet_routes.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/fly-apps/go-example/models"
+	postgrest "github.com/supabase-community/postgrest-go"
+)
+
+func init() {
+	http.HandleFunc("/tweet", createTweet)
+	http.HandleFunc("/tweet/", tweetHandler)
+}
+
+// tweetHandler handles retrieval of tweets and their comments.
+func tweetHandler(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(parts) < 2 {
+		http.NotFound(w, r)
+		return
+	}
+
+	id := parts[1]
+
+	if len(parts) == 2 && r.Method == http.MethodGet {
+		fetchTweet(w, r, id)
+		return
+	}
+
+	if len(parts) == 3 && parts[2] == "comments" && r.Method == http.MethodGet {
+		fetchComments(w, r, id)
+		return
+	}
+
+	http.NotFound(w, r)
+}
+
+// fetchTweet returns a specific tweet with user info.
+func fetchTweet(w http.ResponseWriter, r *http.Request, tweetID string) {
+	ctx := r.Context()
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	client, err := getSupabase(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	qb := client.From("tweets").Select("*,users(*)", "", false)
+	qb = qb.Eq("id", tweetID)
+	data, _, err := qb.Single().Execute()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	var tweet TweetWithUser
+	if err := json.Unmarshal(data, &tweet); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(tweet)
+}
+
+// fetchComments returns comments for a tweet.
+func fetchComments(w http.ResponseWriter, r *http.Request, tweetID string) {
+	ctx := r.Context()
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	client, err := getSupabase(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var comments []CommentWithUser
+	qb := client.From("comments").Select("*,users(*)", "", false)
+	qb = qb.Eq("tweet_id", tweetID)
+	qb = qb.Order("created_at", &postgrest.OrderOpts{Ascending: false})
+	if _, err := qb.ExecuteTo(&comments); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(comments)
+}
+
+// createTweet inserts a new tweet for a user.
+func createTweet(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.NotFound(w, r)
+		return
+	}
+
+	var payload struct {
+		UserID int    `json:"user_id"`
+		Body   string `json:"body"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	client, err := getSupabase(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	qb := client.From("tweets").Insert(map[string]interface{}{
+		"user_id": payload.UserID,
+		"body":    payload.Body,
+	}, false, "", "", "")
+	data, _, err := qb.Single().Execute()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var tweet models.Tweet
+	if err := json.Unmarshal(data, &tweet); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(tweet)
+}

--- a/tweet_types.go
+++ b/tweet_types.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/fly-apps/go-example/models"
+)
+
+// TweetWithUser combines tweet data with its author.
+type TweetWithUser struct {
+	models.Tweet
+	User models.User `json:"users"`
+}
+
+// CommentWithUser combines comment data with its author.
+type CommentWithUser struct {
+	models.Comment
+	User models.User `json:"users"`
+}

--- a/user_routes.go
+++ b/user_routes.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	postgrest "github.com/supabase-community/postgrest-go"
+)
+
+func init() {
+	http.HandleFunc("/user/", userHandler)
+}
+
+// userHandler dispatches user related routes.
+func userHandler(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(parts) < 2 {
+		http.NotFound(w, r)
+		return
+	}
+
+	id := parts[1]
+
+	if len(parts) == 2 && r.Method == http.MethodGet {
+		userTweets(w, r, id)
+		return
+	}
+
+	if len(parts) == 3 && parts[2] == "bio" && r.Method == http.MethodPost {
+		updateBio(w, r, id)
+		return
+	}
+
+	http.NotFound(w, r)
+}
+
+// userTweets returns 10 latest tweets for the specified user.
+func userTweets(w http.ResponseWriter, r *http.Request, userID string) {
+	ctx := r.Context()
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	client, err := getSupabase(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var tweets []TweetWithUser
+	qb := client.From("tweets").Select("*,users(*)", "", false)
+	qb = qb.Eq("user_id", userID)
+	qb = qb.Order("created_at", &postgrest.OrderOpts{Ascending: false})
+	qb = qb.Limit(10, "")
+	if _, err := qb.ExecuteTo(&tweets); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(tweets)
+}
+
+// updateBio updates the bio for a given user.
+func updateBio(w http.ResponseWriter, r *http.Request, userID string) {
+	var payload struct {
+		Bio string `json:"bio"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	client, err := getSupabase(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	qb := client.From("users").Update(map[string]string{"bio": payload.Bio}, "", "")
+	qb = qb.Eq("id", userID)
+	if _, _, err := qb.Execute(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}


### PR DESCRIPTION
## Summary
- add type wrapping tweet and comment with their author data
- add /home endpoint for recent tweets
- add /user, /tweet and comment routes

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897d1dd3a308321b326210bf91a0b83