### PR TITLE
Add authentication endpoints and swagger documentation

### DIFF
--- a/app.go
+++ b/app.go
@@ -10,7 +10,7 @@ import (
 	_ "github.com/et-hicks/imitation-backend/src"
 )
 
-//go:embed templates/*
+//go:embed templates/* docs/*
 var resources embed.FS
 
 var t = template.Must(template.ParseFS(resources, "templates/*"))
@@ -23,11 +23,17 @@ func main() {
 	}
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		data := map[string]string{
-			"Region": os.Getenv("FLY_REGION"),
-		}
+		t.ExecuteTemplate(w, "index.html.tmpl", nil)
+	})
 
-		t.ExecuteTemplate(w, "index.html.tmpl", data)
+	http.HandleFunc("/docs/openapi.json", func(w http.ResponseWriter, r *http.Request) {
+		content, err := resources.ReadFile("docs/openapi.json")
+		if err != nil {
+			http.Error(w, "failed to read openapi spec", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(content)
 	})
 
 	http.HandleFunc("/about", func(w http.ResponseWriter, r *http.Request) {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,680 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Imitation Backend API",
+    "version": "1.0.0",
+    "description": "API documentation for the imitation backend service."
+  },
+  "servers": [
+    {
+      "url": "/",
+      "description": "Current server"
+    }
+  ],
+  "paths": {
+    "/auth/signup": {
+      "post": {
+        "summary": "Create a new user account",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Credentials"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Account created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request payload"
+          },
+          "409": {
+            "description": "Username already exists"
+          }
+        }
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "summary": "Authenticate an existing user",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Credentials"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Login successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request payload"
+          },
+          "401": {
+            "description": "Invalid credentials"
+          }
+        }
+      }
+    },
+    "/home": {
+      "get": {
+        "summary": "List the most recent tweets",
+        "responses": {
+          "200": {
+            "description": "A list of tweets with author information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TweetWithUser"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/{id}": {
+      "get": {
+        "summary": "List the latest tweets for a user",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tweets for the specified user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TweetWithUser"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    },
+    "/user/{id}/bio": {
+      "post": {
+        "summary": "Update a user's bio",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBioRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Bio updated"
+          },
+          "400": {
+            "description": "Invalid request payload"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    },
+    "/tweet": {
+      "post": {
+        "summary": "Create a tweet or comment",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AuthHeader"
+          },
+          {
+            "name": "Parent-Tweet-ID",
+            "in": "header",
+            "required": false,
+            "description": "Required when creating a comment",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTweetRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Created tweet or comment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/Tweet"
+                    },
+                    {
+                      "$ref": "#/components/schemas/Comment"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request payload"
+          },
+          "401": {
+            "description": "Authorization failed"
+          }
+        }
+      }
+    },
+    "/tweet/{id}": {
+      "get": {
+        "summary": "Fetch a tweet with author information",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tweet details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TweetWithUser"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Tweet not found"
+          }
+        }
+      }
+    },
+    "/tweet/{id}/comments": {
+      "get": {
+        "summary": "List comments for a tweet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Comments with author information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CommentWithUser"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/like/{userId}/{targetId}": {
+      "put": {
+        "summary": "Like or unlike a tweet or comment",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "targetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AuthHeader"
+          },
+          {
+            "name": "Is-Comment",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "remove",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "When true, removes an existing like"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Like state updated"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authorization failed"
+          }
+        }
+      }
+    },
+    "/save/{userId}/{tweetId}": {
+      "put": {
+        "summary": "Save or unsave a tweet",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "tweetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AuthHeader"
+          },
+          {
+            "name": "remove",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "When true, removes a saved tweet"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Save state updated"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authorization failed"
+          }
+        }
+      }
+    },
+    "/restack/{userId}/{tweetId}": {
+      "put": {
+        "summary": "Restack a tweet",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "tweetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AuthHeader"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Tweet restacked"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authorization failed"
+          }
+        }
+      }
+    },
+    "/follow/{userId}/{followId}": {
+      "put": {
+        "summary": "Follow another user",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "followId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AuthHeader"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Follow relationship stored"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Authorization failed"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "username": {
+            "type": "string"
+          },
+          "profile_name": {
+            "type": "string"
+          },
+          "profile_url": {
+            "type": "string"
+          },
+          "bio": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "created_at",
+          "username"
+        ]
+      },
+      "Tweet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "user_id": {
+            "type": "integer"
+          },
+          "body": {
+            "type": "string"
+          },
+          "likes": {
+            "type": "integer"
+          },
+          "saves": {
+            "type": "integer"
+          },
+          "restacks": {
+            "type": "integer"
+          },
+          "replies": {
+            "type": "integer"
+          },
+          "is_edited": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_edited_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "user_id",
+          "body"
+        ]
+      },
+      "Comment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "user_id": {
+            "type": "integer"
+          },
+          "tweet_id": {
+            "type": "integer"
+          },
+          "body": {
+            "type": "string"
+          },
+          "likes": {
+            "type": "integer"
+          },
+          "replies": {
+            "type": "integer"
+          },
+          "is_edited": {
+            "type": "boolean"
+          },
+          "last_edited_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "user_id",
+          "tweet_id",
+          "body"
+        ]
+      },
+      "TweetWithUser": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Tweet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "users": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "required": [
+              "users"
+            ]
+          }
+        ]
+      },
+      "CommentWithUser": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Comment"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "users": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "required": [
+              "users"
+            ]
+          }
+        ]
+      },
+      "Credentials": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string",
+            "format": "password"
+          }
+        },
+        "required": [
+          "username",
+          "password"
+        ]
+      },
+      "AuthResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "username"
+        ]
+      },
+      "UpdateBioRequest": {
+        "type": "object",
+        "properties": {
+          "bio": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "bio"
+        ]
+      },
+      "CreateTweetRequest": {
+        "type": "object",
+        "properties": {
+          "body": {
+            "type": "string"
+          },
+          "is_comment": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "body",
+          "is_comment"
+        ]
+      }
+    },
+    "parameters": {
+      "AuthHeader": {
+        "name": "Authorization",
+        "in": "header",
+        "description": "Numeric user identifier",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -42,8 +42,12 @@ func cleanupTables(t *testing.T, db *sql.DB) {
 
 func insertUser(t *testing.T, db *sql.DB, id int) {
 	t.Helper()
-	_, err := db.Exec(`INSERT INTO users (id, username, profile_name, profile_url, bio) VALUES (?, ?, ?, ?, ?)`,
-		id, fmt.Sprintf("user%d", id), fmt.Sprintf("User %d", id), "", "")
+	hash, err := api.HashPasswordForTests("password123")
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO users (id, username, password_hash, profile_name, profile_url, bio) VALUES (?, ?, ?, ?, ?, ?)`,
+		id, fmt.Sprintf("user%d", id), hash, fmt.Sprintf("User %d", id), "", "")
 	if err != nil {
 		t.Fatalf("insert user: %v", err)
 	}
@@ -187,6 +191,54 @@ func TestCreateCommentSuccess(t *testing.T) {
 	}
 	if v, ok := got["tweet_id"].(float64); !ok || int(v) != 42 {
 		t.Fatalf("expected tweet_id=42, got %v", got["tweet_id"])
+	}
+}
+
+func TestSignupHashesPassword(t *testing.T) {
+	db := setupTestDB(t)
+
+	body := bytes.NewBufferString(`{"username":"newuser","password":"super-secret"}`)
+	req := httptest.NewRequest(http.MethodPost, "/auth/signup", body)
+	rr := httptest.NewRecorder()
+	http.DefaultServeMux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+
+	var hash string
+	if err := db.QueryRow(`SELECT password_hash FROM users WHERE username = ?`, "newuser").Scan(&hash); err != nil {
+		t.Fatalf("lookup user: %v", err)
+	}
+	if hash == "" {
+		t.Fatalf("password hash should not be empty")
+	}
+	if hash == "super-secret" {
+		t.Fatalf("password hash stored in plaintext")
+	}
+	if !api.VerifyPasswordForTests(hash, "super-secret") {
+		t.Fatalf("stored hash does not validate password")
+	}
+}
+
+func TestLoginValidatesPassword(t *testing.T) {
+	db := setupTestDB(t)
+
+	hash, err := api.HashPasswordForTests("letmein")
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO users (username, password_hash) VALUES (?, ?)`, "login_user", hash); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	body := bytes.NewBufferString(`{"username":"login_user","password":"letmein"}`)
+	req := httptest.NewRequest(http.MethodPost, "/auth/login", body)
+	rr := httptest.NewRecorder()
+	http.DefaultServeMux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/sql/users.sql
+++ b/sql/users.sql
@@ -1,11 +1,11 @@
-INSERT INTO users (id, username, profile_name, created_at) VALUES
-(1, 'ana_sky', 'Ana Sky', '2022-07-15 09:23:00'),
-(2, 'techtony', 'Tony Sparks', '2022-12-01 10:05:00'),
-(3, 'green_gale', 'Gale Rivers', '2023-03-17 16:45:00'),
-(4, 'bookbree', 'Bree Page', '2023-05-06 12:30:00'),
-(5, 'travel_tom', 'Tom Miles', '2023-08-23 08:15:00'),
-(6, 'music_mia', 'Mia Keys', '2023-10-11 19:50:00'),
-(7, 'chef_char', 'Charlotte Spoon', '2024-01-02 07:40:00'),
-(8, 'sports_sam', 'Sam Fields', '2024-02-18 11:22:00'),
-(9, 'photo_ivy', 'Ivy Lens', '2024-03-30 13:00:00'),
-(10, 'astro_lee', 'Lee Comet', '2024-05-05 15:35:00');
+INSERT INTO users (id, username, password_hash, profile_name, created_at) VALUES
+(1, 'ana_sky', 'ABEiM0RVZneImaq7zN3u/w==:dOMa9qpHVDeWZ3TwQdHnuU7Fn48afx0LrasLEKiNoXE=', 'Ana Sky', '2022-07-15 09:23:00'),
+(2, 'techtony', 'ABEiM0RVZneImaq7zN3u/w==:dOMa9qpHVDeWZ3TwQdHnuU7Fn48afx0LrasLEKiNoXE=', 'Tony Sparks', '2022-12-01 10:05:00'),
+(3, 'green_gale', 'ABEiM0RVZneImaq7zN3u/w==:dOMa9qpHVDeWZ3TwQdHnuU7Fn48afx0LrasLEKiNoXE=', 'Gale Rivers', '2023-03-17 16:45:00'),
+(4, 'bookbree', 'ABEiM0RVZneImaq7zN3u/w==:dOMa9qpHVDeWZ3TwQdHnuU7Fn48afx0LrasLEKiNoXE=', 'Bree Page', '2023-05-06 12:30:00'),
+(5, 'travel_tom', 'ABEiM0RVZneImaq7zN3u/w==:dOMa9qpHVDeWZ3TwQdHnuU7Fn48afx0LrasLEKiNoXE=', 'Tom Miles', '2023-08-23 08:15:00'),
+(6, 'music_mia', 'ABEiM0RVZneImaq7zN3u/w==:dOMa9qpHVDeWZ3TwQdHnuU7Fn48afx0LrasLEKiNoXE=', 'Mia Keys', '2023-10-11 19:50:00'),
+(7, 'chef_char', 'ABEiM0RVZneImaq7zN3u/w==:dOMa9qpHVDeWZ3TwQdHnuU7Fn48afx0LrasLEKiNoXE=', 'Charlotte Spoon', '2024-01-02 07:40:00'),
+(8, 'sports_sam', 'ABEiM0RVZneImaq7zN3u/w==:dOMa9qpHVDeWZ3TwQdHnuU7Fn48afx0LrasLEKiNoXE=', 'Sam Fields', '2024-02-18 11:22:00'),
+(9, 'photo_ivy', 'ABEiM0RVZneImaq7zN3u/w==:dOMa9qpHVDeWZ3TwQdHnuU7Fn48afx0LrasLEKiNoXE=', 'Ivy Lens', '2024-03-30 13:00:00'),
+(10, 'astro_lee', 'ABEiM0RVZneImaq7zN3u/w==:dOMa9qpHVDeWZ3TwQdHnuU7Fn48afx0LrasLEKiNoXE=', 'Lee Comet', '2024-05-05 15:35:00');

--- a/src/auth_routes.go
+++ b/src/auth_routes.go
@@ -1,0 +1,149 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func init() {
+	http.HandleFunc("/auth/signup", signupHandler)
+	http.HandleFunc("/auth/login", loginHandler)
+}
+
+type credentials struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func signupHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.NotFound(w, r)
+		return
+	}
+	var creds credentials
+	if err := json.NewDecoder(r.Body).Decode(&creds); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	creds.Username = strings.TrimSpace(creds.Username)
+	if creds.Username == "" || creds.Password == "" {
+		http.Error(w, "username and password are required", http.StatusBadRequest)
+		return
+	}
+
+	hashed, err := hashPassword(creds.Password)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	ctx := r.Context()
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	db, err := GetDB(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	res, err := db.ExecContext(ctx, "INSERT INTO users (username, password_hash) VALUES (?, ?)", creds.Username, hashed)
+	if err != nil {
+		if isUniqueConstraint(err) {
+			http.Error(w, "username already exists", http.StatusConflict)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"id":       id,
+		"username": creds.Username,
+	})
+}
+
+func loginHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.NotFound(w, r)
+		return
+	}
+	var creds credentials
+	if err := json.NewDecoder(r.Body).Decode(&creds); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	creds.Username = strings.TrimSpace(creds.Username)
+	if creds.Username == "" || creds.Password == "" {
+		http.Error(w, "username and password are required", http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	db, err := GetDB(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var (
+		id           int64
+		storedHashed string
+	)
+	err = db.QueryRowContext(ctx, "SELECT id, password_hash FROM users WHERE username = ?", creds.Username).Scan(&id, &storedHashed)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, "invalid credentials", http.StatusUnauthorized)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if storedHashed == "" {
+		hashed, err := hashPassword(creds.Password)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if _, err := db.ExecContext(ctx, "UPDATE users SET password_hash = ? WHERE id = ?", hashed, id); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		storedHashed = hashed
+	}
+
+	if !verifyPassword(storedHashed, creds.Password) {
+		http.Error(w, "invalid credentials", http.StatusUnauthorized)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"id":       id,
+		"username": creds.Username,
+	})
+}
+
+func isUniqueConstraint(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "unique constraint failed")
+}

--- a/src/connection_bridge.go
+++ b/src/connection_bridge.go
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     username TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
     profile_name TEXT,
     profile_url TEXT,
     bio TEXT
@@ -166,6 +167,42 @@ func applySchema(ctx context.Context, db *sql.DB) error {
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("run schema: %w", err)
 		}
+	}
+	if err := ensurePasswordColumn(ctx, db); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ensurePasswordColumn(ctx context.Context, db *sql.DB) error {
+	rows, err := db.QueryContext(ctx, "PRAGMA table_info(users)")
+	if err != nil {
+		return fmt.Errorf("describe users: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid        int
+			name       string
+			columnType string
+			notNull    int
+			defaultVal sql.NullString
+			primaryKey int
+		)
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultVal, &primaryKey); err != nil {
+			return fmt.Errorf("scan users info: %w", err)
+		}
+		if name == "password_hash" {
+			return nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate users info: %w", err)
+	}
+
+	if _, err := db.ExecContext(ctx, "ALTER TABLE users ADD COLUMN password_hash TEXT NOT NULL DEFAULT ''"); err != nil {
+		return fmt.Errorf("add password column: %w", err)
 	}
 	return nil
 }

--- a/src/passwords.go
+++ b/src/passwords.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+const passwordSaltLength = 16
+
+// hashPassword generates a salted SHA-256 hash for the supplied password.
+func hashPassword(password string) (string, error) {
+	salt := make([]byte, passwordSaltLength)
+	if _, err := rand.Read(salt); err != nil {
+		return "", fmt.Errorf("generate salt: %w", err)
+	}
+	sum := sha256.Sum256(combineSaltAndPassword(salt, password))
+	return base64.StdEncoding.EncodeToString(salt) + ":" + base64.StdEncoding.EncodeToString(sum[:]), nil
+}
+
+// verifyPassword checks whether the provided password matches the stored hash.
+func verifyPassword(hashed, password string) bool {
+	parts := strings.Split(hashed, ":")
+	if len(parts) != 2 {
+		return false
+	}
+	salt, err := base64.StdEncoding.DecodeString(parts[0])
+	if err != nil {
+		return false
+	}
+	digest, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return false
+	}
+	sum := sha256.Sum256(combineSaltAndPassword(salt, password))
+	return subtle.ConstantTimeCompare(digest, sum[:]) == 1
+}
+
+func combineSaltAndPassword(salt []byte, password string) []byte {
+	buf := make([]byte, len(salt)+len(password))
+	copy(buf, salt)
+	copy(buf[len(salt):], password)
+	return buf
+}
+
+// HashPasswordForTests exposes hashing for unit tests.
+func HashPasswordForTests(password string) (string, error) {
+	return hashPassword(password)
+}
+
+// VerifyPasswordForTests exposes password verification for unit tests.
+func VerifyPasswordForTests(hashed, password string) bool {
+	return verifyPassword(hashed, password)
+}

--- a/templates/index.html.tmpl
+++ b/templates/index.html.tmpl
@@ -1,12 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="utf-8" />
+    <title>Imitation Backend API</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css" />
+    <style>
+        body {
+            margin: 0;
+        }
+        #swagger-ui {
+            min-height: 100vh;
+        }
+    </style>
 </head>
 <body>
-<h1>Hello from Fly</h1>
-{{ if .Region }}
-<h2>I'm running in the {{.Region}} region</h2>
-{{end}}
+<div id="swagger-ui"></div>
+<script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+<script>
+    window.onload = () => {
+        SwaggerUIBundle({
+            url: '/docs/openapi.json',
+            dom_id: '#swagger-ui',
+            presets: [SwaggerUIBundle.presets.apis],
+            layout: 'BaseLayout'
+        });
+    };
+</script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- add signup and login handlers that store salted password hashes and update the schema to ensure the new column exists
- refresh seed data and tests to cover hashed credentials and login/signup behaviour
- replace the landing page with Swagger UI backed by an embedded OpenAPI description of the backend routes

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_6903bb3368c88321997ec4d5f86b825d