### PR TITLE
Add endpoints for user tweets, likes, bookmarks and signup page

### DIFF
--- a/app.go
+++ b/app.go
@@ -44,6 +44,10 @@ func main() {
 		t.ExecuteTemplate(w, "about.html.tmpl", data)
 	})
 
+	http.HandleFunc("/signup", func(w http.ResponseWriter, r *http.Request) {
+		t.ExecuteTemplate(w, "signup.html.tmpl", nil)
+	})
+
 	// Serve JSON data from embedded file
 	http.HandleFunc("/data", func(w http.ResponseWriter, r *http.Request) {
 		content, err := resources.ReadFile("data/data.json")

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -167,6 +167,105 @@
         }
       }
     },
+    "/users/{userId}/tweets": {
+      "get": {
+        "summary": "List all tweets authored by a user",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tweets authored by the specified user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TweetWithUser"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid user id"
+          }
+        }
+      }
+    },
+    "/users/{userId}/likes": {
+      "get": {
+        "summary": "List tweets liked by a user",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tweets liked by the specified user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TweetWithUser"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid user id"
+          }
+        }
+      }
+    },
+    "/users/{userId}/bookmarks": {
+      "get": {
+        "summary": "List tweets bookmarked by a user",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tweets bookmarked by the specified user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TweetWithUser"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid user id"
+          }
+        }
+      }
+    },
     "/tweet": {
       "post": {
         "summary": "Create a tweet or comment",

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -61,6 +61,18 @@ func insertTweet(t *testing.T, db *sql.DB, id, userID int, body string) {
 	}
 }
 
+func seedUsersAndTweets(t *testing.T, db *sql.DB, userCount, tweetsPerUser int) {
+	t.Helper()
+	tweetID := 1
+	for user := 1; user <= userCount; user++ {
+		insertUser(t, db, user)
+		for i := 0; i < tweetsPerUser; i++ {
+			insertTweet(t, db, tweetID, user, fmt.Sprintf("User %d tweet %d", user, i+1))
+			tweetID++
+		}
+	}
+}
+
 func TestHomeReturnsTen(t *testing.T) {
 	db := setupTestDB(t)
 	for i := 1; i <= 10; i++ {
@@ -314,5 +326,144 @@ func TestFollowAuthCheck(t *testing.T) {
 
 	if rr2.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, body=%s", rr2.Code, rr2.Body.String())
+	}
+}
+
+func TestUserTweetsQueryAndEndpoint(t *testing.T) {
+	db := setupTestDB(t)
+	seedUsersAndTweets(t, db, 5, 5)
+
+	userID := 3
+
+	rows, err := db.Query(api.UserTweetsSelect, userID)
+	if err != nil {
+		t.Fatalf("query tweets: %v", err)
+	}
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate tweets: %v", err)
+	}
+	if count != 5 {
+		t.Fatalf("want 5 tweets from SQL, got %d", count)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/users/3/tweets", nil)
+	rr := httptest.NewRecorder()
+	http.DefaultServeMux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+
+	var got []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("want 5 tweets from endpoint, got %d", len(got))
+	}
+	for i, row := range got {
+		if v, ok := row["user_id"].(float64); !ok || int(v) != userID {
+			t.Fatalf("row %d: want user_id=%d, got %v", i, userID, row["user_id"])
+		}
+	}
+}
+
+func TestUserBookmarksQueryAndEndpoint(t *testing.T) {
+	db := setupTestDB(t)
+	seedUsersAndTweets(t, db, 5, 5)
+
+	userID := 1
+	firstForeignTweetID := 6 // tweets from user 2
+	for i := 0; i < 5; i++ {
+		tweetID := firstForeignTweetID + i
+		if _, err := db.Exec(`INSERT INTO user_tweet_interactions (user_id, tweet_id, is_saved) VALUES (?, ?, 1)`, userID, tweetID); err != nil {
+			t.Fatalf("insert bookmark: %v", err)
+		}
+	}
+
+	rows, err := db.Query(api.UserBookmarkedTweetsSelect, userID)
+	if err != nil {
+		t.Fatalf("query bookmarks: %v", err)
+	}
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate bookmarks: %v", err)
+	}
+	if count != 5 {
+		t.Fatalf("want 5 bookmarks from SQL, got %d", count)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/users/1/bookmarks", nil)
+	rr := httptest.NewRecorder()
+	http.DefaultServeMux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+
+	var got []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("want 5 bookmarks from endpoint, got %d", len(got))
+	}
+}
+
+func TestUserLikesQueryAndEndpoint(t *testing.T) {
+	db := setupTestDB(t)
+	seedUsersAndTweets(t, db, 5, 5)
+
+	userID := 2
+	startTweetID := 11 // tweets from user 3
+	for i := 0; i < 5; i++ {
+		tweetID := startTweetID + i
+		if _, err := db.Exec(`INSERT INTO user_tweet_interactions (user_id, tweet_id, is_liked) VALUES (?, ?, 1)`, userID, tweetID); err != nil {
+			t.Fatalf("insert like: %v", err)
+		}
+	}
+
+	rows, err := db.Query(api.UserLikedTweetsSelect, userID)
+	if err != nil {
+		t.Fatalf("query likes: %v", err)
+	}
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate likes: %v", err)
+	}
+	if count != 5 {
+		t.Fatalf("want 5 likes from SQL, got %d", count)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/users/2/likes", nil)
+	rr := httptest.NewRecorder()
+	http.DefaultServeMux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rr.Code, rr.Body.String())
+	}
+
+	var got []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("want 5 likes from endpoint, got %d", len(got))
 	}
 }

--- a/src/user_queries.go
+++ b/src/user_queries.go
@@ -1,0 +1,77 @@
+package api
+
+const (
+	// UserTweetsSelect lists tweets authored by the provided user ordered from newest to oldest.
+	UserTweetsSelect = `
+SELECT
+    t.id,
+    t.user_id,
+    t.body,
+    t.likes,
+    t.saves,
+    t.restacks,
+    t.replies,
+    t.is_edited,
+    t.created_at,
+    t.last_edited_at,
+    u.id,
+    u.created_at,
+    u.username,
+    u.profile_name,
+    u.profile_url,
+    u.bio
+FROM tweets t
+JOIN users u ON u.id = t.user_id
+WHERE t.user_id = ?
+ORDER BY t.created_at DESC, t.id DESC`
+
+	// UserLikedTweetsSelect lists tweets liked by the provided user ordered from newest like target.
+	UserLikedTweetsSelect = `
+SELECT
+    t.id,
+    t.user_id,
+    t.body,
+    t.likes,
+    t.saves,
+    t.restacks,
+    t.replies,
+    t.is_edited,
+    t.created_at,
+    t.last_edited_at,
+    u.id,
+    u.created_at,
+    u.username,
+    u.profile_name,
+    u.profile_url,
+    u.bio
+FROM user_tweet_interactions uti
+JOIN tweets t ON t.id = uti.tweet_id
+JOIN users u ON u.id = t.user_id
+WHERE uti.user_id = ? AND uti.is_liked = 1
+ORDER BY t.created_at DESC, t.id DESC`
+
+	// UserBookmarkedTweetsSelect lists tweets bookmarked by the provided user ordered from newest bookmark target.
+	UserBookmarkedTweetsSelect = `
+SELECT
+    t.id,
+    t.user_id,
+    t.body,
+    t.likes,
+    t.saves,
+    t.restacks,
+    t.replies,
+    t.is_edited,
+    t.created_at,
+    t.last_edited_at,
+    u.id,
+    u.created_at,
+    u.username,
+    u.profile_name,
+    u.profile_url,
+    u.bio
+FROM user_tweet_interactions uti
+JOIN tweets t ON t.id = uti.tweet_id
+JOIN users u ON u.id = t.user_id
+WHERE uti.user_id = ? AND uti.is_saved = 1
+ORDER BY t.created_at DESC, t.id DESC`
+)

--- a/src/user_routes.go
+++ b/src/user_routes.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 
 func init() {
 	http.HandleFunc("/user/", userHandler)
+	http.HandleFunc("/users/", usersHandler)
 }
 
 // userHandler dispatches user related routes.
@@ -56,33 +58,96 @@ func userTweets(w http.ResponseWriter, r *http.Request, userID string) {
 		return
 	}
 
-	rows, err := db.QueryContext(ctx, `
-SELECT
-    t.id,
-    t.user_id,
-    t.body,
-    t.likes,
-    t.saves,
-    t.restacks,
-    t.replies,
-    t.is_edited,
-    t.created_at,
-    t.last_edited_at,
-    u.id,
-    u.created_at,
-    u.username,
-    u.profile_name,
-    u.profile_url,
-    u.bio
-FROM tweets t
-JOIN users u ON u.id = t.user_id
-WHERE t.user_id = ?
-ORDER BY t.created_at DESC, t.id DESC
-LIMIT 10
-`, uid)
+	tweets, err := fetchTweets(ctx, db, UserTweetsSelect+"\nLIMIT 10", uid)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(tweets)
+	log.Println("sent successfully")
+}
+
+// usersHandler dispatches requests for plural user resources.
+func usersHandler(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(parts) < 3 {
+		http.NotFound(w, r)
+		return
+	}
+
+	if parts[0] != "users" {
+		http.NotFound(w, r)
+		return
+	}
+
+	uid, err := strconv.Atoi(parts[1])
+	if err != nil {
+		http.Error(w, "invalid user id", http.StatusBadRequest)
+		return
+	}
+
+	if r.Method != http.MethodGet {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch parts[2] {
+	case "tweets":
+		handleUserTweets(w, r, uid)
+	case "likes":
+		handleUserLikes(w, r, uid)
+	case "bookmarks":
+		handleUserBookmarks(w, r, uid)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func handleUserTweets(w http.ResponseWriter, r *http.Request, userID int) {
+	tweets, err := fetchTweetsForUser(r.Context(), UserTweetsSelect, userID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeTweetsResponse(w, tweets)
+}
+
+func handleUserLikes(w http.ResponseWriter, r *http.Request, userID int) {
+	tweets, err := fetchTweetsForUser(r.Context(), UserLikedTweetsSelect, userID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeTweetsResponse(w, tweets)
+}
+
+func handleUserBookmarks(w http.ResponseWriter, r *http.Request, userID int) {
+	tweets, err := fetchTweetsForUser(r.Context(), UserBookmarkedTweetsSelect, userID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeTweetsResponse(w, tweets)
+}
+
+func fetchTweetsForUser(ctx context.Context, query string, userID int) ([]TweetWithUser, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	db, err := GetDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return fetchTweets(ctx, db, query, userID)
+}
+
+func fetchTweets(ctx context.Context, db *sql.DB, query string, args ...any) ([]TweetWithUser, error) {
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -90,16 +155,17 @@ LIMIT 10
 	for rows.Next() {
 		tweet, err := scanTweetWithUser(rows)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+			return nil, err
 		}
 		tweets = append(tweets, tweet)
 	}
 	if err := rows.Err(); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return nil, err
 	}
+	return tweets, nil
+}
 
+func writeTweetsResponse(w http.ResponseWriter, tweets []TweetWithUser) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(tweets)
 	log.Println("sent successfully")

--- a/templates/signup.html.tmpl
+++ b/templates/signup.html.tmpl
@@ -1,0 +1,26 @@
+{{define "signup.html.tmpl"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Sign Up</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css" />
+</head>
+<body>
+    <main>
+        <h1>Create your account</h1>
+        <form method="post" action="/auth/signup">
+            <label for="username">Username</label>
+            <input id="username" name="username" type="text" required />
+
+            <label for="password">Password</label>
+            <input id="password" name="password" type="password" required />
+
+            <button type="submit">Sign Up</button>
+        </form>
+        <p>This form submits to the <code>/auth/signup</code> endpoint which accepts JSON payloads in production.</p>
+    </main>
+</body>
+</html>
+{{end}}


### PR DESCRIPTION
## Summary
- add dedicated GET routes for user tweets, liked tweets, and bookmarked tweets backed by shared SQL queries
- expand handler tests to seed SQLite data and verify the SQL and HTTP responses for the new endpoints
- document the endpoints in the OpenAPI spec and add a signup HTML page served at /signup

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_6903fb217cf0832196c9cab4813132f8